### PR TITLE
Keep rotated logs as poisoned logs

### DIFF
--- a/nixops/modules/ofborg/log-collector.nix
+++ b/nixops/modules/ofborg/log-collector.nix
@@ -47,8 +47,9 @@ in {
           };
 
           script = ''
-            find "${config.services.ofborg.config_merged.log_storage.path}" -type f -mtime +7 -delete
-            find "${config.services.ofborg.config_merged.log_storage.path}" -mindepth 1 -type d -empty -mtime +7 -delete
+            find "${config.services.ofborg.config_merged.log_storage.path}" \
+              -type f -mtime +7 -not -name '*.json' \
+              -exec sh -c "echo '***DELETED LOGS***' > {}" \;
           '';
         };
 


### PR DESCRIPTION
So, not having tested due to lack of an already-setup test infrastructure, here is what I mean in https://github.com/NixOS/ofborg/issues/117#issuecomment-372867033