### PR TITLE
Specify the external URL for prometheus alerts

### DIFF
--- a/nixops/modules/monitoring.nix
+++ b/nixops/modules/monitoring.nix
@@ -53,6 +53,8 @@ in {
     services.prometheus = {
       enable = true;
 
+      extraFlags = [ "--web.external-url=https://${config.services.ofborg.website.domain}/" ];
+
       alertmanagerURL = [ "http://127.0.0.1:9093" ];
       alertmanager = {
         enable = true;


### PR DESCRIPTION
Makes received alert's source links useful.