### PR TITLE
remove the aarch community builder from filesystem alerts

### DIFF
--- a/nixops/modules/monitoring.nix
+++ b/nixops/modules/monitoring.nix
@@ -116,13 +116,13 @@ in {
             }
             {
               alert = "FreeInodes4HrsAway";
-              expr = ''predict_linear(node_filesystem_files_free{mountpoint="/"}[1h], 4 * 3600) <= 0'';
+              expr = ''predict_linear(node_filesystem_files_free{mountpoint="/", instance!="aarch64.nixos.community:9100"}[1h], 4 * 3600) <= 0'';
               for = "5m";
               labels.severity = "page";
             }
             {
               alert = "FreeSpace2HrsAway";
-              expr = ''predict_linear(node_filesystem_free{mountpoint="/"}[1h], 2 * 3600) <= 0'';
+              expr = ''predict_linear(node_filesystem_free{mountpoint="/", instance!="aarch64.nixos.community:9100"}[1h], 2 * 3600) <= 0'';
               for = "5m";
               labels.severity = "page";
             }


### PR DESCRIPTION
The aarch builder is used by the ofborg infrastructure, but if it runs
out of diskspace enough to stall builds there's another alert that will
still trigger.