### PR TITLE
Remove {extra-,}known-users

### DIFF
--- a/nixops/modules/site.nix
+++ b/nixops/modules/site.nix
@@ -29,14 +29,6 @@ in {
 
     services.ofborg.config_public = readJSON ../../repos/ofborg/config.public.json;
 
-    services.ofborg.config_private = {
-      runner.known_users = let
-          nixpkgsContributors =
-            (readJSON ../../repos/ofborg/config.known-users.json).runner.known_users;
-          extra = readJSON ../../repos/ofborg/config.extra-known-users.json;
-        in nixpkgsContributors ++ extra;
-    };
-
     users.mutableUsers = false;
   };
 }


### PR DESCRIPTION
ofborg no longer makes a distinction between known users and unknown
users; all PRs get built.

The only distinction remaining is between trusted and untrusted users:
trusted users will have their builds be built on darwin, in addition to
the x86_64-linux and aarch64-linux builders everyone gets.

---

Depends on https://github.com/NixOS/ofborg/pull/482.