### PR TITLE
nixops: generalize evaluator setup

### DIFF
--- a/nixops/network.nix
+++ b/nixops/network.nix
@@ -85,135 +85,36 @@
       {}
       nodes;
   in allImported)
-  // {
+  // (
+  let
+    numMachines = last: builtins.genList (n: n + 1) last;
+
+    mkEvaluator = n: {
+      name = "packet-spot-eval-${toString n}";
+      value = { resources, ... }: {
+        deployment.targetEnv = "packet";
+        deployment.packet = {
+          project = "86d5d066-b891-4608-af55-a481aa2c0094";
+          keyPair = resources.packetKeyPairs.dummy;
+          facility = "ewr1";
+          plan = "m1.xlarge.x86";
+          ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
+          spotInstance = true;
+          spotPriceMax = "2.00";
+          tags = { buildkite = "...yes..."; };
+        };
+
+        services.ofborg.builder.enable = true;
+        services.ofborg.evaluator.enable = true;
+
+        nix.gc_free_gb = 100;
+        nix.buildCores = 24;
+      };
+    };
+  in
+  {
     resources.packetKeyPairs.dummy = {
       project = "86d5d066-b891-4608-af55-a481aa2c0094";
     };
-    packet-spot-eval-1 = { resources, ... }: {
-      deployment.targetEnv = "packet";
-      deployment.packet = {
-        project = "86d5d066-b891-4608-af55-a481aa2c0094";
-        keyPair = resources.packetKeyPairs.dummy;
-        facility = "ewr1";
-        plan = "m1.xlarge.x86";
-        ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
-        spotInstance = true;
-        spotPriceMax = "2.00";
-        tags = {
-          buildkite = "...yes...";
-        };
-      };
-
-      nix.gc_free_gb = 100;
-      services.ofborg.builder.enable = true;
-      services.ofborg.evaluator.enable = true;
-
-      nix.buildCores = 24;
-    };
-    packet-spot-eval-2 = { resources, ... }: {
-      deployment.targetEnv = "packet";
-      deployment.packet = {
-        project = "86d5d066-b891-4608-af55-a481aa2c0094";
-        keyPair = resources.packetKeyPairs.dummy;
-        facility = "ewr1";
-        plan = "m1.xlarge.x86";
-        ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
-        spotInstance = true;
-        spotPriceMax = "2.00";
-        tags = {
-          buildkite = "...yes...";
-        };
-      };
-
-      nix.gc_free_gb = 100;
-      services.ofborg.builder.enable = true;
-      services.ofborg.evaluator.enable = true;
-
-      nix.buildCores = 24;
-    };
-    packet-spot-eval-3 = { resources, ... }: {
-      deployment.targetEnv = "packet";
-      deployment.packet = {
-        project = "86d5d066-b891-4608-af55-a481aa2c0094";
-        keyPair = resources.packetKeyPairs.dummy;
-        facility = "ewr1";
-        plan = "m1.xlarge.x86";
-        ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
-        spotInstance = true;
-        spotPriceMax = "2.00";
-        tags = {
-          buildkite = "...yes...";
-        };
-      };
-
-      nix.gc_free_gb = 100;
-      services.ofborg.builder.enable = true;
-      services.ofborg.evaluator.enable = true;
-
-      nix.buildCores = 24;
-    };
-    packet-spot-eval-4 = { resources, ... }: {
-      deployment.targetEnv = "packet";
-      deployment.packet = {
-        project = "86d5d066-b891-4608-af55-a481aa2c0094";
-        keyPair = resources.packetKeyPairs.dummy;
-        facility = "ewr1";
-        plan = "m1.xlarge.x86";
-        ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
-        spotInstance = true;
-        spotPriceMax = "2.00";
-        tags = {
-          buildkite = "...yes...";
-        };
-      };
-
-      nix.gc_free_gb = 100;
-      services.ofborg.builder.enable = true;
-      services.ofborg.evaluator.enable = true;
-
-      nix.buildCores = 24;
-    };
-    packet-spot-eval-5 = { resources, ... }: {
-      deployment.targetEnv = "packet";
-      deployment.packet = {
-        project = "86d5d066-b891-4608-af55-a481aa2c0094";
-        keyPair = resources.packetKeyPairs.dummy;
-        facility = "ewr1";
-        plan = "m1.xlarge.x86";
-        ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
-        spotInstance = true;
-        spotPriceMax = "2.00";
-        tags = {
-          buildkite = "...yes...";
-        };
-      };
-
-      nix.gc_free_gb = 100;
-      services.ofborg.builder.enable = true;
-      services.ofborg.evaluator.enable = true;
-
-      nix.buildCores = 24;
-    };
-    packet-spot-eval-6 = { resources, ... }: {
-      deployment.targetEnv = "packet";
-      deployment.packet = {
-        project = "86d5d066-b891-4608-af55-a481aa2c0094";
-        keyPair = resources.packetKeyPairs.dummy;
-        facility = "ewr1";
-        plan = "m1.xlarge.x86";
-        ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
-        spotInstance = true;
-        spotPriceMax = "2.00";
-        tags = {
-          buildkite = "...yes...";
-        };
-      };
-
-      nix.gc_free_gb = 100;
-      services.ofborg.builder.enable = true;
-      services.ofborg.evaluator.enable = true;
-
-      nix.buildCores = 24;
-    };
-
-  }
+  } // builtins.listToAttrs (map (n: mkEvaluator n) (numMachines 6))
+)


### PR DESCRIPTION
No more having to copy ~20 lines for every new evaluator that we need to
add. Just change `numMachines 6` to `numMachines N`, where N is the
desired number of total evaluators.
