### PR TITLE
enable and configure rabbitmq-exporter

### DIFF
--- a/nixops/modules/monitoring.nix
+++ b/nixops/modules/monitoring.nix
@@ -167,6 +167,16 @@ in {
         }
 
         {
+          job_name = "rabbitmq";
+          static_configs = [
+            {
+              targets = [ "${rabbitmq.domain}:9419" ];
+            }
+          ];
+        }
+
+        # TODO: remove?
+        {
           job_name = "ofborg-queue";
           metrics_path = "/prometheus.php";
           scheme = "https";

--- a/nixops/modules/rabbitmq/default.nix
+++ b/nixops/modules/rabbitmq/default.nix
@@ -42,6 +42,7 @@ in {
     services.phpfpm.enable_main = true;
     services.nginx = {
       enable = true;
+      # TODO: remove?
       virtualHosts."${cfg.domain}" = pkgs.nginxVhostPHP
         (pkgs.mutate ./queue-monitor {
           user = cfg.monitoring_username;
@@ -50,7 +51,7 @@ in {
         config.services.phpfpm.pools.main.socket;
     };
 
-    networking.firewall.allowedTCPPorts = [ 80 443 5671 15671 ];
+    networking.firewall.allowedTCPPorts = [ 80 443 5671 9419 15671 ];
     networking.firewall.extraCommands = let
       acceptPortFromPeer = peer: port:
         ''
@@ -103,5 +104,21 @@ in {
            ].
          '';
      };
+
+    systemd.services."prometheus-rabbitmq-exporter" = {
+      after = [ "rabbitmq.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.prometheus-rabbitmq-exporter}/bin/rabbitmq_exporter";
+        DynamicUser = "yes";
+      };
+      environment = {
+        PUBLISH_PORT = "9419";
+        RABBIT_CAPABILITIE = "bert,no_sort";
+        RABBIT_EXPORTERS = "connections,exchange,node,queue";
+        RABBIT_USER = cfg.monitoring_username;
+        RABBIT_PASSWORD = cfg.monitoring_password;
+      };
+    };
   };
 }


### PR DESCRIPTION
This exposes some of the same data as the queue-monitor and a bunch
more. Once prometheus has some historical data that can probably be
replaced.