### PR TITLE
kill obsolete machines

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -35,5 +35,9 @@ fetchrepo repos/log-viewer https://github.com/samueldr/ofborg-viewer.git master
 if [ "${1:-x}" != "--do-it-live" ]; then
     nixops deploy --dry-activate --check --allow-recreate
 else
-    nixops deploy --check --allow-recreate
+    # We want to remove unused systems, but definitely don't want to remove
+    # core-0. To achieve this, we first deploy only to core-0, followed by a
+    # deploy to the rest of the hosts, where obsolete hosts will be dropped.
+    nixops deploy --check --allow-recreate --include core-0
+    nixops deploy --check --allow-recreate --kill-obsolete --exclude core-0
 fi


### PR DESCRIPTION
This will release the extra evaluators whenever we scale the amount of
evaluators down.

We exclude core-0 because it would be really nice to not delete that
host...

---

`--include core-0` on the second instance so we don't deploy twice to the evaluators we do keep.