### PR TITLE
nix: ensure SRI hashes are not used in nixpkgs

### DIFF
--- a/nixops/modules/ofborg/helpers.nix
+++ b/nixops/modules/ofborg/helpers.nix
@@ -1,4 +1,17 @@
 { config, pkgs }:
+let
+  nixCustom = pkgs.nix.overrideDerivation (drv: {
+    patches = [
+      (pkgs.fetchpatch {
+        name = "nixpkgs-disallow-sri.patch";
+        url = "https://github.com/LnL7/nix/commit/48888b1ff2d3b8f5f106f06e8c20c10f9c942a53.patch";
+        sha256 = "03ncp2mrsp2nbdyfc0jr9gf76mf3vw425x0vwq8r4fsgjgd2c3li";
+      })
+    ];
+    # The tests check SRI hashes, which won't pass anymore.
+    doInstallCheck = false;
+  });
+in
 {
   rustborgservice = bin: {
     enable = true;
@@ -7,7 +20,7 @@
     wantedBy = [ "multi-user.target" ];
 
     path = with pkgs; [
-      nix
+      nixCustom
       git
       curl
       bash


### PR DESCRIPTION
These where not available in nix 2.0, which currently the minimum
version nixpkgs master should be compatible with.