### PR TITLE
Use packet domain for ipxe script

### DIFF
--- a/nixops/network.nix
+++ b/nixops/network.nix
@@ -106,7 +106,7 @@
           keyPair = resources.packetKeyPairs.dummy;
           facility = "ewr1";
           plan = "m1.xlarge.x86";
-          ipxeScriptUrl = "http://147.75.194.151/result/x86/netboot.ipxe";
+          ipxeScriptUrl = "http://images.packet.net/nixos/installer-pre/x86/netboot.ipxe";
           spotInstance = true;
           spotPriceMax = "2.00";
           tags = { buildkite = "...yes..."; };


### PR DESCRIPTION
This will help to ensure deploys continue working even after we lose
control of the IP.

---

cc @grahamc 