### PR TITLE
ci: add nix-collect-garbage step

### DIFF
--- a/ci/terraform-import.yml
+++ b/ci/terraform-import.yml
@@ -55,3 +55,17 @@ steps:
       - ./enter-env.sh nix-shell --run "morph deploy ./morph-network/default.nix boot"
     agents:
       ofborg-infrastructure: true
+
+  - block: "Confirm nix-collect-garbage"
+    key: collect-garbage-confirm
+
+  - label: "nix-collect-garbage"
+    concurrency_group: ofborg-infrastructure-deploy
+    concurrency: 1
+    depends_on:
+      - deploy-boot
+      - collect-garbage-confirm
+    command:
+      -  ./enter-env.sh morph exec --on="*" ./morph-network/default.nix nix-collect-garbage
+    agents:
+      ofborg-infrastructure: true

--- a/ci/terraform-import.yml
+++ b/ci/terraform-import.yml
@@ -22,7 +22,7 @@ steps:
     key: deploy-dry-activate
     commands:
       - ./build/clone.sh
-      - ./enter-env.sh nix-shell --run "morph deploy ./morph-network/default.nix dry-activate"
+      - ./enter-env.sh morph deploy ./morph-network/default.nix dry-activate
     agents:
       ofborg-infrastructure: true
 
@@ -37,7 +37,7 @@ steps:
     key: deploy-test
     commands:
       - ./build/clone.sh
-      - ./enter-env.sh nix-shell --run "morph deploy ./morph-network/default.nix test --upload-secrets"
+      - ./enter-env.sh morph deploy ./morph-network/default.nix test --upload-secrets
     agents:
       ofborg-infrastructure: true
 
@@ -52,7 +52,7 @@ steps:
     key: deploy-boot
     commands:
       - ./build/clone.sh
-      - ./enter-env.sh nix-shell --run "morph deploy ./morph-network/default.nix boot"
+      - ./enter-env.sh morph deploy ./morph-network/default.nix boot
     agents:
       ofborg-infrastructure: true
 


### PR DESCRIPTION
No need to do the nix-shell --run dance, since enter-env.sh is already
run using the shell.nix.