### PR TITLE
ci: collect garbage before dry activation

### DIFF
--- a/ci/terraform-import.yml
+++ b/ci/terraform-import.yml
@@ -14,6 +14,14 @@ steps:
 
   - wait
 
+  - label: "nix-collect-garbage"
+    concurrency_group: ofborg-infrastructure-deploy
+    concurrency: 1
+    command:
+      - ./enter-env.sh morph exec --on="*" ./morph-network/default.nix nix-collect-garbage
+    agents:
+      ofborg-infrastructure: true
+
   - label: "Dry Activation"
     concurrency_group: ofborg-infrastructure-deploy
     concurrency: 1
@@ -51,17 +59,5 @@ steps:
     commands:
       - ./build/clone.sh
       - ./enter-env.sh morph deploy ./morph-network/default.nix boot
-    agents:
-      ofborg-infrastructure: true
-
-  - block: "Confirm nix-collect-garbage"
-    key: collect-garbage-confirm
-
-  - label: "nix-collect-garbage"
-    concurrency_group: ofborg-infrastructure-deploy
-    concurrency: 1
-    depends_on: collect-garbage-confirm
-    command:
-      -  ./enter-env.sh morph exec --on="*" ./morph-network/default.nix nix-collect-garbage
     agents:
       ofborg-infrastructure: true


### PR DESCRIPTION
This ensures we can deploy even if we are low on space.

No blocking, but still `concurrency: 1`.