### PR TITLE
rabbitmq: remove SKIPVERIFY

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9158eca70ae59e73fae23be5d13d3fa0cfc78b4",
-        "sha256": "0cnmvnvin9ixzl98fmlm3g17l6w95gifqfb3rfxs55c0wj2ddy53",
+        "rev": "f217c0ea7c148ddc0103347051555c7c252dcafb",
+        "sha256": "0cyksxg2lnzxd0pss09rmmk2c2axz0lf9wvgvfng59nwf8dpq2kf",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9158eca70ae59e73fae23be5d13d3fa0cfc78b4.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f217c0ea7c148ddc0103347051555c7c252dcafb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nixops/modules/rabbitmq/default.nix
+++ b/nixops/modules/rabbitmq/default.nix
@@ -55,11 +55,6 @@ in {
       environment = {
         PUBLISH_PORT = "9419";
         RABBIT_URL = "https://${cfg.domain}";
-        SKIPVERIFY = "true"; # yeah, sue me. the current version in nixpkgs
-        # fails on https://github.com/kbudde/rabbitmq_exporter/issues/149
-        # and while I'd like to upgrade it, it was a can of worms... and
-        # this username and password isn't very interesting, anyway.
-
         RABBIT_EXPORTERS = "exchange,node,queue";
         RABBIT_USER = cfg.monitoring_username;
         RABBIT_PASSWORD = cfg.monitoring_password;


### PR DESCRIPTION
Since the rabbitmq_exporter was updated to 1.0.0-RC7.1, the cloudAMQP
root ceritifcate should be supported now.