### PR TITLE
shell.nix: remove goPackagePath from buildGoModule's

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -25,7 +25,6 @@ pkgs.mkShell {
       (pkgs.buildGoModule rec {
         pname = "terraform-provider-cloudamqp";
         version = "1.8.6";
-        goPackagePath = "github.com/cloudamqp/terraform-provider-cloudamqp";
         subPackages = [ "." ];
         src = pkgs.fetchFromGitHub {
           owner = "cloudamqp";
@@ -65,7 +64,6 @@ pkgs.mkShell {
       (pkgs.buildGoModule rec {
         pname = "terraform-provider-rabbitmq";
         version = "1.5.1";
-        goPackagePath = "github.com/cyrilgdn/terraform-provider-rabbitmq";
         subPackages = [ "." ];
         src = pkgs.fetchFromGitHub {
           owner = "cyrilgdn";


### PR DESCRIPTION
This is disallowed as of
https://github.com/NixOS/nixpkgs/commit/863706ef307a4fa62370b7ee0db85f10a422e880.