### PR TITLE
enter-env: remove secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ private/*
 deploy.key*
 ssh-config
 terraform.plan
+vars.auto.tfvars.json


### PR DESCRIPTION
The script writes them out again, so let's remove them after we're done
in the environment.