### PR TITLE
enter-env: add hosts in ssh config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ repos
 private/*
 deploy.key*
 ssh-config
+ssh-config.inc
 terraform.plan
 vars.auto.tfvars.json


### PR DESCRIPTION
This way we don't need to spelunk in morph-network/default.nix to find
the host IP.

---

QoL (for me, at least). Makes it possible to `ssh -F ssh-config core` or `ssh -F ssh-config eval-1` -- no need to specify the `-i` flag or the IP of the host.