### PR TITLE
amqp.tf: web_stop -> web_stomp

### DIFF
--- a/terraform/base/amqp.tf
+++ b/terraform/base/amqp.tf
@@ -32,7 +32,7 @@ resource "cloudamqp_plugin" "instance-plugin-prometheus" {
   enabled = true
 }
 
-resource "cloudamqp_plugin" "instance-plugin-web_stop" {
+resource "cloudamqp_plugin" "instance-plugin-web_stomp" {
   instance_id = cloudamqp_instance.instance.id
   name = "rabbitmq_web_stomp"
   enabled = true


### PR DESCRIPTION
For posterity:

    $ ./enter-env.sh
    $ cd terraform/base
    $ $EDITOR amqp.tf # and fix the typo
    $ terraform init
    $ terraform state mv cloudamqp_plugin.instance-plugin-web_stop cloudamqp_plugin.instance-plugin-web_stomp
    $ terraform plan
    $ git add amqp.tf && git commit -v
    $ git push vaultpush

---

https://github.com/ofborg/infrastructure/commit/72beb8e690a91648d3a523dacb7d3e7668c34477#r46973864