### PR TITLE
ofborg/evaluator: 128 build users

### DIFF
--- a/nixops/modules/ofborg/evaluator.nix
+++ b/nixops/modules/ofborg/evaluator.nix
@@ -3,7 +3,8 @@ let
   inherit (lib) mkIf mkOption types;
   helpers = import ./helpers.nix { inherit config pkgs; };
   cfg = config.services.ofborg.evaluator;
-in {
+in
+{
   options = {
     services.ofborg = {
       evaluator = {
@@ -16,6 +17,8 @@ in {
   };
 
   config = mkIf cfg.enable rec {
+    nix.nrBuildUsers = 128;
+
     systemd = {
       services = {
         ofborg-evaluator =


### PR DESCRIPTION
Work around the rare appearance of

    error: all build users are currently in use; consider creating additional users and adding them to the 'nixbld' group