### PR TITLE
ofborg/evaluator: automatic gc once a week

### DIFF
--- a/nixops/modules/ofborg/evaluator.nix
+++ b/nixops/modules/ofborg/evaluator.nix
@@ -17,7 +17,13 @@ in
   };
 
   config = mkIf cfg.enable rec {
-    nix.nrBuildUsers = 128;
+    nix = {
+      nrBuildUsers = 128;
+      gc = {
+        automatic = true;
+        dates = "weekly";
+      };
+    };
 
     systemd = {
       services = {


### PR DESCRIPTION
This way we don't have to manually intervene by starting a deploy,
just to run the GC steps.