### PR TITLE
Add an option to deploy-reboot every machine

### DIFF
--- a/ci/reboot-individual.sh
+++ b/ci/reboot-individual.sh
@@ -29,7 +29,7 @@ step() {
     depends_on: deploy-$host-confirm-reboot
     concurrency_group: ofborg-infrastructure-individual-reboot
     concurrency: $NRHOSTS
-    key: deploy-$host-reboot
+    key: deploy-$host-secrets
     commands:
       - ./build/clone.sh
       - ./enter-env.sh morph upload-secrets ./morph-network/default.nix --on="$host"

--- a/ci/reboot-individual.sh
+++ b/ci/reboot-individual.sh
@@ -27,7 +27,7 @@ step() {
       ofborg-infrastructure: true
 
   - label: "Pushing secrets to $host after reboot"
-    depends_on: deploy-$host-confirm-reboot
+    depends_on: deploy-$host-reboot
     concurrency_group: ofborg-infrastructure-individual-reboot
     concurrency: $NRHOSTS
     key: deploy-$host-secrets

--- a/ci/reboot-individual.sh
+++ b/ci/reboot-individual.sh
@@ -52,4 +52,4 @@ hosts="$(nix-instantiate -E --eval --json \
   for host in $hosts; do
     step "$host"
   done
-) | cat # | buildkite-agent pipeline upload
+) | buildkite-agent pipeline upload

--- a/ci/reboot-individual.sh
+++ b/ci/reboot-individual.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash ../shell.nix
+# shellcheck shell=bash
+
+set -eux
+
+scriptroot="$(dirname "$(realpath "$0")")"
+NRHOSTS="$(ls "$scriptroot"/../morph-network/machines/*.expr.nix | wc -l)"
+
+step() {
+  host="$1"
+
+  cat <<EOF
+  - block: ":rotating_light: Deploy $host with a reboot :rotating_light: "
+    key: deploy-$host-confirm-reboot
+
+  - label: ":nixos: reboot deploy $host"
+    depends_on: deploy-$host-confirm-reboot
+    key: deploy-$host-reboot
+    concurrency_group: ofborg-infrastructure-individual-reboot
+    concurrency: $NRHOSTS
+    command:
+      - ./build/clone.sh
+      - ./enter-env.sh morph deploy ./morph-network/default.nix boot --on="$host" --reboot
+    agents:
+      ofborg-infrastructure: true
+
+  - label: "Pushing secrets to $host after reboot"
+    depends_on: deploy-$host-confirm-reboot
+    concurrency_group: ofborg-infrastructure-individual-reboot
+    concurrency: $NRHOSTS
+    key: deploy-$host-reboot
+    commands:
+      - ./build/clone.sh
+      - ./enter-env.sh morph upload-secrets ./morph-network/default.nix --on="$host"
+    agents:
+      ofborg-infrastructure: true
+
+EOF
+}
+
+hosts="$(nix-instantiate -E --eval --json \
+  "builtins.attrNames
+    (builtins.removeAttrs
+      (import "$scriptroot"/../morph-network/default.nix)
+      [ \"network\" ])" \
+  | jq -r '. | to_entries | map("\(.value)") | join(" ")')"
+
+(
+  echo "steps:"
+
+  for host in $hosts; do
+    step "$host"
+  done
+) | cat # | buildkite-agent pipeline upload

--- a/ci/reboot-individual.sh
+++ b/ci/reboot-individual.sh
@@ -13,6 +13,7 @@ step() {
   cat <<EOF
   - block: ":rotating_light: Deploy $host with a reboot :rotating_light: "
     key: deploy-$host-confirm-reboot
+    depends_on: prompt-individual-reboots
 
   - label: ":nixos: reboot deploy $host"
     depends_on: deploy-$host-confirm-reboot

--- a/ci/terraform-deploy.yml
+++ b/ci/terraform-deploy.yml
@@ -10,6 +10,7 @@ steps:
       ofborg-infrastructure: true
 
   - label: "prompt-individual-reboots"
+    key: "prompt-individual-reboots"
     command:
       - ./enter-env.sh ./ci/reboot-individual.sh
     agents:

--- a/ci/terraform-deploy.yml
+++ b/ci/terraform-deploy.yml
@@ -9,6 +9,12 @@ steps:
     agents:
       ofborg-infrastructure: true
 
+  - label: "prompt-individual-reboots"
+    command:
+      - ./enter-env.sh ./ci/reboot-individual.sh
+    agents:
+      ofborg-infrastructure: true
+
   - wait
 
   - label: "Dry Activation"


### PR DESCRIPTION
New machines need a reboot. There should be a better way to do this, but this is the cheap and cheerful (but sadly manual) way to deal.