### PR TITLE
Remove logs upon GC to free up inodes and disk space

### DIFF
--- a/ci/collect-garbage.sh
+++ b/ci/collect-garbage.sh
@@ -15,6 +15,7 @@ step() {
     concurrency_group: ofborg-infrastructure-gc
     concurrency: $NRHOSTS
     command:
+      - ./enter-env.sh morph exec --on="$host" ./morph-network/default.nix -- rm -rf /nix/var/log/nix/
       - ./enter-env.sh morph exec --on="$host" ./morph-network/default.nix nix-collect-garbage
     agents:
       ofborg-infrastructure: true


### PR DESCRIPTION
nix-collect-garbage will fail when there are no free inodes because of a
database-related error. By removing the build logs, we can free up a
decent amount of inodes that should hopefully get us enough free
inodes to collect garbage.