### PR TITLE
WIP monitoring: fixup ofborg stats collector port

### DIFF
--- a/nixops/modules/monitoring.nix
+++ b/nixops/modules/monitoring.nix
@@ -153,7 +153,9 @@ in {
           job_name = "prometheus";
           static_configs = [
             {
-              targets = cfg.monitoring_nodes;
+              targets = lib.unique
+                (map (add_port 9898)
+                  cfg.monitoring_nodes);
             }
           ];
         }


### PR DESCRIPTION
Maybe, at some point, :80 was forwarded to :9898, but not anymore; this
target has been unreachable and a new dashboard has been unable to be
created due to the absence of these metrics. Hopefully, this should
bring them back.