### PR TITLE
Bump morph

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -7,14 +7,14 @@ let
     config = { allowUnfree = true; };
   };
 
-  morph = pkgs.morph.overrideAttrs ({ patches ? [ ], ... }: {
-    patches = patches ++ [
-      (pkgs.fetchpatch {
-        url = "https://github.com/DBCDK/morph/commit/ff4e0cd5f7cbdb9be50661d75560a40d5928530c.patch";
-        sha256 = "1ChMLjAh8Tmrf0G8tQuvRVDro8/VbnFbBWoFEglB4XA=";
-      })
-    ];
-  });
+  morph = import
+    (pkgs.fetchFromGitHub {
+      owner = "DBCDK";
+      repo = "morph";
+      rev = "081a5752825d4884d82b5b3b84baa426fadc2307";
+      sha256 = "lZIZlwRTv1skWuwGBLXF4gyyaXF5IXjC36savQOh2JI=";
+    })
+    { };
 in
 pkgs.mkShell {
   buildInputs = [


### PR DESCRIPTION
They recently switched from using the experimental nix(1) interface back
to the legacy nix-instantiate and friends. We can't currently deploy
because of issues caused by these experimental features, such as:

    error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override
    Error while running `nix eval ..`: exit status 1