### PR TITLE
modules/monitoring: enable recommendedProxySettings

### DIFF
--- a/nixops/modules/monitoring.nix
+++ b/nixops/modules/monitoring.nix
@@ -64,6 +64,7 @@ in {
 
     services.nginx = {
       enable = true;
+      recommendedProxySettings = true;
 
       virtualHosts."${cfg.domain}" = {
         enableACME = true;


### PR DESCRIPTION
Otherwise, after a recent upgrade to Grafana, it was no longer possible
to log in.

ref: https://community.grafana.com/t/origin-not-allowed-messages-after-upgrade-to-8-3-6/60550/