### PR TITLE
Add and update nix-channel in buildkite

### DIFF
--- a/buildkite.yml
+++ b/buildkite.yml
@@ -4,6 +4,9 @@ steps:
     concurrency_group: ofborg-infrastructure-terraform
     concurrency: 1
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./enter-env.sh ./ci/terraform-plan.sh base ./ci/terraform-base-apply.yml ./ci/terraform-rabbitmq-plan.yml
     agents:
       ofborg-infrastructure: true

--- a/ci/collect-garbage.sh
+++ b/ci/collect-garbage.sh
@@ -15,6 +15,9 @@ step() {
     concurrency_group: ofborg-infrastructure-gc
     concurrency: $NRHOSTS
     command:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./enter-env.sh morph exec --on="$host" ./morph-network/default.nix nix-collect-garbage
     agents:
       ofborg-infrastructure: true

--- a/ci/terraform-base-apply.yml
+++ b/ci/terraform-base-apply.yml
@@ -7,6 +7,9 @@ steps:
     concurrency: 1
     depends_on: terraform-base-confirm
     command:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./enter-env.sh ./ci/terraform-apply.sh base ./ci/terraform-rabbitmq-plan.yml
     agents:
       ofborg-infrastructure: true

--- a/ci/terraform-deploy.yml
+++ b/ci/terraform-deploy.yml
@@ -5,6 +5,9 @@ steps:
     concurrency_group: ofborg-infrastructure-deploy
     concurrency: 1
     command:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./enter-env.sh ./ci/collect-garbage.sh
     agents:
       ofborg-infrastructure: true
@@ -16,6 +19,9 @@ steps:
     concurrency: 1
     key: deploy-dry-activate
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./build/clone.sh
       - ./enter-env.sh morph deploy ./morph-network/default.nix dry-activate
     agents:
@@ -31,6 +37,9 @@ steps:
     depends_on: deploy-confirm-test
     key: deploy-test
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./build/clone.sh
       - ./enter-env.sh morph deploy ./morph-network/default.nix test --upload-secrets
     agents:
@@ -46,6 +55,9 @@ steps:
     depends_on: deploy-confirm-boot
     key: deploy-boot
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./build/clone.sh
       - ./enter-env.sh morph deploy ./morph-network/default.nix boot
     agents:
@@ -61,6 +73,9 @@ steps:
     depends_on: deploy-confirm-reboot
     key: deploy-reboot
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./build/clone.sh
       - ./enter-env.sh morph deploy ./morph-network/default.nix boot --reboot
     agents:
@@ -72,6 +87,9 @@ steps:
     depends_on: deploy-reboot
     key: deploy-post-reboot-upload-secrets
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./build/clone.sh
       - ./enter-env.sh morph upload-secrets ./morph-network/default.nix
     agents:

--- a/ci/terraform-import.yml
+++ b/ci/terraform-import.yml
@@ -7,6 +7,9 @@ env:
 steps:
   - label: "Server Intake"
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./enter-env.sh ./make-targets.sh
       - git diff --cached --exit-code
       - buildkite-agent pipeline upload ./ci/terraform-deploy.yml

--- a/ci/terraform-rabbitmq-apply.yml
+++ b/ci/terraform-rabbitmq-apply.yml
@@ -8,6 +8,9 @@ steps:
     depends_on: terraform-rabbitmq-confirm
     key: terraform-rabbitmq-apply
     command:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./enter-env.sh ./ci/terraform-apply.sh rabbitmq ./ci/terraform-import.yml
     agents:
       ofborg-infrastructure: true

--- a/ci/terraform-rabbitmq-plan.yml
+++ b/ci/terraform-rabbitmq-plan.yml
@@ -3,6 +3,9 @@ steps:
     concurrency_group: ofborg-infrastructure-terraform
     concurrency: 1
     commands:
+      # Broken in 2.14.x -- users no longer look up root channels
+      - nix-channel --add https://nixos.org/channels/nixpkgs-unstable
+      - nix-channel --update
       - ./enter-env.sh ./ci/terraform-plan.sh rabbitmq ./ci/terraform-rabbitmq-apply.yml ./ci/terraform-import.yml
     agents:
       ofborg-infrastructure: true


### PR DESCRIPTION
The buildkite user doesn't look up root's channels anymore, so we need to make sure the buildkite user has channels setup. Otherwise, old versions of bash will be problematic (i.e. the one we have in Amazon Linux).