### PR TITLE
Update Nixpkgs, use Nix 2.13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,10 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666776005,
+        "lastModified": 1673295039,
+        "narHash": "sha256-AsdYgE8/GPwcelGgrntlijMg4t3hLFJFCRF3tL5WVjA=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "f6648ca0698d1611d7eadfa72b122252b833f86c",
+        "rev": "87b9d090ad39b25b2400029c64825fc2a8868943",
         "type": "github"
       },
       "original": {
@@ -21,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671728284,
-        "narHash": "sha256-u5Tlz4bl2vb9CB+L/A/Xp8F32062vo3K6yl7J9FBXdc=",
+        "lastModified": 1678298120,
+        "narHash": "sha256-iaV5xqgn29xy765Js3EoZePQyZIlLZA3pTYtTnKkejg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7ba7b4599367c07f2f5d1e26151b68a71a1336b2",
+        "rev": "1e383aada51b416c6c27d4884d2e258df201bc11",
         "type": "github"
       },
       "original": {
@@ -73,11 +74,11 @@
         "nixpkgs-for-php": "nixpkgs-for-php"
       },
       "locked": {
-        "lastModified": 1671735808,
-        "narHash": "sha256-p5V0+hkz7wEh10iDo/A1QA98sPMYLMoWIQGQmGOVoJw=",
+        "lastModified": 1676408389,
+        "narHash": "sha256-oeT1AONVTIcxSuBpuwXAUB88ULpRA3u/6mJIqLDJ0Y0=",
         "owner": "NixOS",
         "repo": "ofborg",
-        "rev": "6d5ad2f34bad811885dffeaac33d5a3546848123",
+        "rev": "cf2c6712bd7342406e799110e7cd465aa250cdca",
         "type": "github"
       },
       "original": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "652e92b8064949a11bc193b90b74cb727f2a1405",
-        "sha256": "19vq1n9m73xfd8d521sxvxgv3fmpdk6lgwvij2cy6h88x58ijdx2",
+        "rev": "c90c4025bb6e0c4eaf438128a3b2640314b1c58d",
+        "sha256": "12rrrbfcw9p4ykadjjvbbn38fc9xknf7x96yknxfmjvllhfm1fcl",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/652e92b8064949a11bc193b90b74cb727f2a1405.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/c90c4025bb6e0c4eaf438128a3b2640314b1c58d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nixops/modules/ofborg/default.nix
+++ b/nixops/modules/ofborg/default.nix
@@ -58,6 +58,6 @@ in {
     ./evaluator.nix
   ];
 
-  config.nix.package = pkgs.nixVersions.nix_2_11;
+  config.nix.package = pkgs.nixVersions.nix_2_13;
   config.system.stateVersion = "23.05";
 }


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'darwin':
    'github:LnL7/nix-darwin/f6648ca0698d1611d7eadfa72b122252b833f86c' (2022-10-26)
  → 'github:LnL7/nix-darwin/87b9d090ad39b25b2400029c64825fc2a8868943' (2023-01-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/7ba7b4599367c07f2f5d1e26151b68a71a1336b2' (2022-12-22)
  → 'github:nixos/nixpkgs/1e383aada51b416c6c27d4884d2e258df201bc11' (2023-03-08)
• Updated input 'ofborg':
    'github:NixOS/ofborg/6d5ad2f34bad811885dffeaac33d5a3546848123' (2022-12-22)
  → 'github:NixOS/ofborg/cf2c6712bd7342406e799110e7cd465aa250cdca' (2023-02-14)